### PR TITLE
fix: document Graphviz system dep + add setuptools

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,34 @@
 
 ## Installation
 
-It is recommended to build a virtual environment before installing dependencies for this project as it can reconfigure environment variables.
+### System dependencies
+
+YARL renders the AST using [Graphviz](https://graphviz.org). Install the binary first — without it, `python src/main.py` will crash with `FileNotFoundError: 'dot'` after parsing.
 
 ```bash
-$ virtualenv env
+# macOS
+brew install graphviz
+
+# Debian / Ubuntu
+sudo apt-get install graphviz
+
+# Windows
+choco install graphviz
+```
+
+### Python environment
+
+```bash
+# Linux / macOS
+$ python3 -m venv env
 $ source env/bin/activate
+
+# Windows (PowerShell)
+$ python -m venv env
+$ .\env\Scripts\Activate.ps1
 ```
 
-or 
-
-```bash
-$ ./env/Scripts/Activate.ps1
-```
-
-According the OS you're currently using.
-
-After this, install the requirements (as we are using rich, typer, anytree, click and some other libraries in this project) and YARL in developer mode with as it can have some changes later
+Then install the Python dependencies and YARL in editable mode:
 
 ```bash
 $ pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 anytree==2.9.0
+setuptools>=65
 click==8.1.3
 colorama==0.4.6
 graphviz==0.20.1


### PR DESCRIPTION
Smoke-tested install on Python 3.14 from a clean clone. Two undocumented blockers:

1. `python setup.py develop` failed with `No module named 'setuptools'` — Python 3.12+ no longer bundles it. Added `setuptools>=65`.
2. `python src/main.py samples/parser/simple_sample.yarl --debug` crashed with `FileNotFoundError: 'dot'`. anytree's UniqueDotExporter shells out to the Graphviz binary. Added 'System dependencies' section with brew/apt/choco install commands.

After both fixes, the sample compiles end-to-end.